### PR TITLE
fix: bash process for Mac PortTokenProcessList

### DIFF
--- a/BlossomiShymae.Briar/Utils/Behaviors/PortTokenWithProcessList.cs
+++ b/BlossomiShymae.Briar/Utils/Behaviors/PortTokenWithProcessList.cs
@@ -44,7 +44,7 @@ namespace BlossomiShymae.Briar.Utils.Behaviors
                     processStartInfo = new ProcessStartInfo()
                     {
                         FileName = "/bin/bash",
-                        Arguments = "-c \"\"\"ps x -o args | grep 'LeagueClientUx'\"\"\"",
+                        Arguments = "-c \"ps x -o args | grep 'LeagueClientUx'\"",
                         WindowStyle = ProcessWindowStyle.Hidden,
                         CreateNoWindow = true,
                         RedirectStandardOutput = true,


### PR DESCRIPTION
This enables MacOS support for Briar